### PR TITLE
userdata: expose set/get methods for protocol userdata

### DIFF
--- a/coordinator.go
+++ b/coordinator.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/Sirupsen/logrus"
-	"github.com/davecgh/go-spew/spew"
 )
 
 const (
@@ -157,8 +155,6 @@ func (c *Coordinator) GetOffset(topic string, partition int32) (int64, error) {
 // groupAssignments is only called by the leader and is responsible for assigning
 // topic-partitions to the members in the group via a protocol common to the group.
 func (c *Coordinator) groupAssignments(resp *sarama.JoinGroupResponse) (map[string]*sarama.ConsumerGroupMemberAssignment, error) {
-	logrus.Info("groupAssignments - JoinGroupResponse")
-	spew.Dump(resp)
 	// build Candidates.
 	members, err := resp.GetMembers()
 	if err != nil {

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -1,0 +1,3 @@
+package cg
+
+var _ Protocol = &HashRing{}

--- a/protocol.go
+++ b/protocol.go
@@ -1,20 +1,30 @@
 package cg
 
-type topicPartitions map[string][]int32
+// TopicPartitions is a map of topics and the partition numbers in that topic.
+type TopicPartitions map[string][]int32
+
+// Member represents a consumer in a consumer group. The MemberID is assigned by Kafka
+// and the UserData is provided by the consumer when it joins the group via the Protocol
+// that was common between all consumers.
+type Member struct {
+	MemberID string
+	UserData []byte
+}
 
 // Candidates represents all members of the Consumer Group which need to decide
 // how to devide up all the TopicPartitions among themselves.
 type Candidates struct {
-	MemberIDs       []string
-	TopicPartitions topicPartitions
+	Members         []Member
+	TopicPartitions TopicPartitions
 }
 
 // Assignment is the result of a Protocol determining which TopicPartitions from
 // Candidates should be assigned to specific MembersIDs.
-type Assignment map[string]topicPartitions
+type Assignment map[string]TopicPartitions
 
 // Protocol is an agreed-upon method between all consumer group members of how to
 // divide TopicPartitions amongst themselves.
 type Protocol interface {
 	Assign(Candidates) Assignment
+	UserData() []byte
 }


### PR DESCRIPTION
It is important for protocols to be able to write metadata about the member that can be used in topic-partition assignment. This requires protocols to expose a UserData function and the Assign method receive a list of members with the UserData that was provided.